### PR TITLE
Disable Wikipedia and MedlinePlus feature in Firefox

### DIFF
--- a/app/manifest.firefox.json
+++ b/app/manifest.firefox.json
@@ -243,9 +243,7 @@
         "*://*.google.co.zm/*",
         "*://*.google.co.zw/*",
         "*://*.bing.com/*",
-        "*://*.search.yahoo.com/*",
-        "*://*.wikipedia.org/*",
-        "*://*.nlm.nih.gov/medlineplus/*"
+        "*://*.search.yahoo.com/*"
       ],
       "js": [
         "bower_components/jquery/dist/jquery.min.js",

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -236,7 +236,7 @@
         "*://*.bing.com/*",
         "*://*.search.yahoo.com/*",
         "*://*.wikipedia.org/*",
-        "*://*.nlm.nih.gov/medlineplus/*"
+        "*://medlineplus.gov/*"
       ],
       "js": [
         "bower_components/jquery/dist/jquery.min.js",

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -97,8 +97,8 @@ var updateLinks = function() {
     hrefSelector = 'a.external.text';
     honLogoSize = 'wide';
   }
-  // Match Mediaplus
-  else if (chrome.omnibox && window.location.host.indexOf('nlm') > -1) {
+  // Match MedlinePlus
+  else if (chrome.omnibox && window.location.host.indexOf('medlineplus') > -1) {
     hrefSelector = '.reveal';
     honLogoSize = 'wide';
   }

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -1,4 +1,8 @@
 'use strict';
+
+// Detect Firefox's API feature
+var isFirefox = typeof InstallTrigger !== 'undefined';
+
 var requestHonCode = function(event, link) {
   var domain = honcode.getDomainFromUrl(link);
   var layerId = 'layer' + event.target.id;
@@ -93,12 +97,12 @@ var updateLinks = function() {
     hrefSelector = 'li.b_algo h2>a';
   }
   // Match Wikipedia
-  else if (chrome.omnibox && window.location.host.indexOf('wikipedia') > -1) {
+  else if (!isFirefox && window.location.host.indexOf('wikipedia') > -1) {
     hrefSelector = 'a.external.text';
     honLogoSize = 'wide';
   }
   // Match MedlinePlus
-  else if (chrome.omnibox && window.location.host.indexOf('medlineplus') > -1) {
+  else if (!isFirefox && window.location.host.indexOf('medlineplus') > -1) {
     hrefSelector = '.reveal';
     honLogoSize = 'wide';
   }

--- a/test/casper.js
+++ b/test/casper.js
@@ -98,7 +98,7 @@ casper.test.begin(wikiPage, 2, function suite(test) {
   });
 });
 
-// Mediaplus
+// MedlinePlus
 casper.test.begin(medlinePage, 1, function suite(test) {
 
   casper.start('https://medlineplus.gov/triglycerides.html',


### PR DESCRIPTION
`chrome.omnibox` is not working in content scripts.

Test :
 * https://medlineplus.gov/cervicalcancer.html
 * https://en.wikipedia.org/wiki/Cancer