### PR TITLE
Fix popup layout with empty domain

### DIFF
--- a/app/styles.scss/popup.scss
+++ b/app/styles.scss/popup.scss
@@ -70,6 +70,7 @@ a:hover {
 
 #certification {
   color: white;
+  min-height: 103px;
   h2, h3 {
     text-align: center;
   }


### PR DESCRIPTION
Before

<img width="250" alt="before" src="https://cloud.githubusercontent.com/assets/2843501/22436694/67c962d6-e725-11e6-9b9c-46e199cb88e4.png">


After

<img width="250" alt="after" src="https://cloud.githubusercontent.com/assets/2843501/22436702/6b4f3336-e725-11e6-8d7a-38afe6ef6658.png">


